### PR TITLE
Add user authentication with private company management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+server/database.sqlite
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -42,9 +42,81 @@ cd <YOUR_PROJECT_NAME>
 # Step 3: Install the necessary dependencies.
 npm i
 
-# Step 4: Start the development server with auto-reloading and an instant preview.
+# Step 4: Seed the SQLite database from the bundled JSON dataset.
+npm run db:seed
+
+# Step 5: Start the API server (exposes http://localhost:4000 by default).
+npm run server
+
+# Step 6: Start the Vite development server with auto-reloading and an instant preview.
 npm run dev
 ```
+
+> The frontend expects the API to be reachable at `http://localhost:4000`. You can change this by setting a `VITE_API_BASE_URL`
+> environment variable before running the Vite dev server or building the app.
+
+## Authentication and working with private data
+
+- Strona główna jest dostępna publicznie i prezentuje wyłącznie firmy oznaczone jako publiczne.
+- Zarejestrowani użytkownicy mogą logować się, dodawać nowe firmy i decydować, czy dane mają być widoczne publicznie.
+- Po zalogowaniu panel użytkownika jest dostępny pod adresem [`/dashboard`](http://localhost:5173/dashboard) i pozwala na dodawanie wpisów przez formularz.
+
+### Rejestracja i logowanie przez API
+
+```sh
+# Rejestracja nowego użytkownika
+curl -X POST http://localhost:4000/api/auth/register \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"twoj_login","password":"twoje_haslo"}'
+
+# Logowanie i pobranie tokenu sesji
+curl -X POST http://localhost:4000/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"twoj_login","password":"twoje_haslo"}'
+```
+
+Każda odpowiedź zwraca token (pole `token`), który należy przekazywać w nagłówku `Authorization: Bearer TOKEN` przy wywoływaniu chronionych endpointów.
+
+### Dodawanie firm z wykorzystaniem API
+
+```sh
+curl -X POST http://localhost:4000/api/companies \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer TOKEN' \
+  -d '{
+        "companyName": "Moja Firma",
+        "krsNIPorHRB": "1234567890",
+        "status": "Active",
+        "description": "Opis działalności",
+        "country": "Poland",
+        "industry": "Technology",
+        "employeeCount": "51-200",
+        "foundedYear": 2020,
+        "address": "ul. Przykładowa 1, 00-000 Warszawa",
+        "website": "https://example.com",
+        "contactEmail": "contact@example.com",
+        "phoneNumber": "+48 123 456 789",
+        "revenue": "5M PLN",
+        "management": ["Jan Kowalski", "Anna Nowak"],
+        "productsAndServices": ["Produkt A", "Usługa B"],
+        "technologiesUsed": ["React", "Node.js"],
+        "lastUpdated": "2024-01-01T00:00:00.000Z",
+        "isPublic": true
+      }'
+```
+
+### Import wielu firm w jednym żądaniu
+
+```sh
+curl -X POST http://localhost:4000/api/companies/import \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer TOKEN' \
+  -d '{"companies": [ { ... }, { ... } ]}'
+```
+
+Endpoint `/api/companies?mine=true` zwraca pełną listę firm utworzonych przez zalogowanego użytkownika – zarówno publicznych, jak i prywatnych.
+
+> ⚠️ Polecenie `npm run db:seed` usuwa wszystkie dotychczasowe wpisy firm (łącznie z prywatnymi) i czyści aktywne sesje. Użytkownicy pozostają zapisani, ale będą musieli zalogować się ponownie.
 
 **Edit a file directly in GitHub**
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "db:seed": "node server/seed.mjs",
+    "server": "node server/index.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/server/index.mjs
+++ b/server/index.mjs
@@ -1,0 +1,670 @@
+import http from 'node:http';
+import { spawn } from 'node:child_process';
+import crypto from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const dbPath = path.join(__dirname, 'database.sqlite');
+const PORT = process.env.PORT || 4000;
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
+
+const escapeSql = (value) => value.replace(/'/g, "''");
+
+const runQuery = (sql) =>
+  new Promise((resolve, reject) => {
+    const child = spawn('sqlite3', [dbPath, '-json', sql]);
+    let output = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      output += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr || `sqlite3 exited with code ${code}`));
+        return;
+      }
+
+      try {
+        const parsed = output ? JSON.parse(output) : [];
+        resolve(parsed);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  });
+
+const runStatements = (statements) =>
+  new Promise((resolve, reject) => {
+    const child = spawn('sqlite3', [dbPath]);
+    let stderr = '';
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr || `sqlite3 exited with code ${code}`));
+      } else {
+        resolve();
+      }
+    });
+
+    statements.forEach((statement) => {
+      child.stdin.write(`${statement}\n`);
+    });
+
+    child.stdin.end();
+  });
+
+const ensureSchema = async () => {
+  await runStatements([
+    "PRAGMA foreign_keys = ON;",
+    `CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );`,
+    `CREATE TABLE IF NOT EXISTS sessions (
+      token TEXT PRIMARY KEY,
+      user_id INTEGER NOT NULL,
+      expires_at TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );`,
+    `CREATE TABLE IF NOT EXISTS companies (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      company_name TEXT NOT NULL,
+      krs_nip_or_hrb TEXT NOT NULL,
+      status TEXT NOT NULL,
+      description TEXT NOT NULL,
+      country TEXT NOT NULL,
+      industry TEXT NOT NULL,
+      employee_count TEXT NOT NULL,
+      founded_year INTEGER NOT NULL,
+      address TEXT NOT NULL,
+      website TEXT NOT NULL,
+      contact_email TEXT NOT NULL,
+      phone_number TEXT NOT NULL,
+      revenue TEXT NOT NULL,
+      management TEXT NOT NULL,
+      products_and_services TEXT NOT NULL,
+      technologies_used TEXT NOT NULL,
+      last_updated TEXT NOT NULL,
+      owner_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+      is_public INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );`,
+    'CREATE INDEX IF NOT EXISTS idx_companies_owner ON companies(owner_id);',
+    'CREATE INDEX IF NOT EXISTS idx_companies_public ON companies(is_public);',
+    'CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions(user_id);',
+  ]);
+};
+
+const purgeExpiredSessions = () =>
+  runStatements(["DELETE FROM sessions WHERE expires_at <= datetime('now');"]);
+
+const readRequestBody = (req) =>
+  new Promise((resolve, reject) => {
+    let body = '';
+
+    req.on('data', (chunk) => {
+      body += chunk;
+      if (body.length > 1_000_000) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+      }
+    });
+
+    req.on('end', () => {
+      resolve(body);
+    });
+
+    req.on('error', (error) => {
+      reject(error);
+    });
+  });
+
+const parseJsonBody = async (req) => {
+  const body = await readRequestBody(req);
+
+  if (!body) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(body);
+  } catch (error) {
+    throw new Error('Invalid JSON payload');
+  }
+};
+
+const hashPassword = (password) => {
+  const salt = crypto.randomBytes(16);
+  const derivedKey = crypto.pbkdf2Sync(password, salt, 310000, 32, 'sha256');
+  return `${salt.toString('hex')}:${derivedKey.toString('hex')}`;
+};
+
+const verifyPassword = (password, storedHash) => {
+  const [saltHex, hashHex] = storedHash.split(':');
+
+  if (!saltHex || !hashHex) {
+    return false;
+  }
+
+  const salt = Buffer.from(saltHex, 'hex');
+  const derivedKey = crypto.pbkdf2Sync(password, salt, 310000, 32, 'sha256');
+
+  try {
+    return crypto.timingSafeEqual(Buffer.from(hashHex, 'hex'), derivedKey);
+  } catch (error) {
+    return false;
+  }
+};
+
+const createSession = async (userId) => {
+  await purgeExpiredSessions();
+  const token = crypto.randomBytes(48).toString('hex');
+  const expiresAt = new Date(Date.now() + SESSION_TTL_MS).toISOString();
+
+  await runQuery(`INSERT INTO sessions (token, user_id, expires_at) VALUES ('${escapeSql(token)}', ${userId}, '${escapeSql(expiresAt)}') RETURNING token;`);
+
+  return { token, expiresAt };
+};
+
+const authenticateRequest = async (req) => {
+  const authHeader = req.headers.authorization;
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return null;
+  }
+
+  const token = authHeader.slice(7).trim();
+
+  if (!token) {
+    return null;
+  }
+
+  const escapedToken = escapeSql(token);
+  const rows = await runQuery(`
+    SELECT users.id AS user_id, users.username, sessions.expires_at
+    FROM sessions
+    INNER JOIN users ON users.id = sessions.user_id
+    WHERE sessions.token = '${escapedToken}'
+      AND sessions.expires_at > datetime('now');
+  `);
+
+  if (rows.length === 0) {
+    return null;
+  }
+
+  const row = rows[0];
+  return { id: row.user_id, username: row.username };
+};
+
+const parseStringArray = (value) => {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => String(item).trim())
+      .filter((item) => item.length > 0);
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter((item) => item.length > 0);
+  }
+
+  return [];
+};
+
+const prepareCompanyData = (payload, ownerId) => {
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('Invalid company payload');
+  }
+
+  const getRequiredString = (key) => {
+    const rawValue = payload[key];
+    if (typeof rawValue !== 'string') {
+      throw new Error(`Field "${key}" is required`);
+    }
+    const value = rawValue.trim();
+    if (!value) {
+      throw new Error(`Field "${key}" cannot be empty`);
+    }
+    return value;
+  };
+
+  const companyName = getRequiredString('companyName');
+  const krsNIPorHRB = getRequiredString('krsNIPorHRB');
+  const status = getRequiredString('status');
+  const description = getRequiredString('description');
+  const country = getRequiredString('country');
+  const industry = getRequiredString('industry');
+  const employeeCount = getRequiredString('employeeCount');
+  const address = getRequiredString('address');
+  const website = getRequiredString('website');
+  const contactEmail = getRequiredString('contactEmail');
+  const phoneNumber = getRequiredString('phoneNumber');
+  const revenue = getRequiredString('revenue');
+
+  const foundedYearValue = payload.foundedYear;
+  const foundedYear = typeof foundedYearValue === 'number' ? foundedYearValue : Number(foundedYearValue);
+
+  if (!Number.isInteger(foundedYear) || foundedYear <= 0) {
+    throw new Error('Field "foundedYear" must be a positive integer year');
+  }
+
+  const management = parseStringArray(payload.management);
+  const productsAndServices = parseStringArray(payload.productsAndServices);
+  const technologiesUsed = parseStringArray(payload.technologiesUsed);
+
+  const lastUpdatedValue = typeof payload.lastUpdated === 'string' && payload.lastUpdated.trim().length > 0
+    ? payload.lastUpdated.trim()
+    : new Date().toISOString();
+
+  const isPublic = payload.isPublic === false ? 0 : 1;
+
+  return {
+    company_name: escapeSql(companyName),
+    krs_nip_or_hrb: escapeSql(krsNIPorHRB),
+    status: escapeSql(status),
+    description: escapeSql(description),
+    country: escapeSql(country),
+    industry: escapeSql(industry),
+    employee_count: escapeSql(employeeCount),
+    founded_year: foundedYear,
+    address: escapeSql(address),
+    website: escapeSql(website),
+    contact_email: escapeSql(contactEmail),
+    phone_number: escapeSql(phoneNumber),
+    revenue: escapeSql(revenue),
+    management: escapeSql(JSON.stringify(management)),
+    products_and_services: escapeSql(JSON.stringify(productsAndServices)),
+    technologies_used: escapeSql(JSON.stringify(technologiesUsed)),
+    last_updated: escapeSql(lastUpdatedValue),
+    owner_id: ownerId ?? null,
+    is_public: isPublic,
+  };
+};
+
+const insertCompany = async (payload, ownerId) => {
+  const data = prepareCompanyData(payload, ownerId);
+
+  const columns = [
+    'company_name',
+    'krs_nip_or_hrb',
+    'status',
+    'description',
+    'country',
+    'industry',
+    'employee_count',
+    'founded_year',
+    'address',
+    'website',
+    'contact_email',
+    'phone_number',
+    'revenue',
+    'management',
+    'products_and_services',
+    'technologies_used',
+    'last_updated',
+    'owner_id',
+    'is_public',
+  ];
+
+  const values = [
+    `'${data.company_name}'`,
+    `'${data.krs_nip_or_hrb}'`,
+    `'${data.status}'`,
+    `'${data.description}'`,
+    `'${data.country}'`,
+    `'${data.industry}'`,
+    `'${data.employee_count}'`,
+    data.founded_year,
+    `'${data.address}'`,
+    `'${data.website}'`,
+    `'${data.contact_email}'`,
+    `'${data.phone_number}'`,
+    `'${data.revenue}'`,
+    `'${data.management}'`,
+    `'${data.products_and_services}'`,
+    `'${data.technologies_used}'`,
+    `'${data.last_updated}'`,
+    data.owner_id === null ? 'NULL' : data.owner_id,
+    data.is_public,
+  ];
+
+  const sql = `INSERT INTO companies (${columns.join(', ')}) VALUES (${values.join(', ')}) RETURNING *;`;
+  const rows = await runQuery(sql);
+  return rows.length > 0 ? rows[0] : null;
+};
+
+const parseJsonColumn = (value) => {
+  if (typeof value !== 'string') {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    return [];
+  }
+};
+
+const mapCompanyRow = (row) => ({
+  id: row.id,
+  companyName: row.company_name,
+  krsNIPorHRB: row.krs_nip_or_hrb,
+  status: row.status,
+  description: row.description,
+  country: row.country,
+  industry: row.industry,
+  employeeCount: row.employee_count,
+  foundedYear: row.founded_year,
+  address: row.address,
+  website: row.website,
+  contactEmail: row.contact_email,
+  phoneNumber: row.phone_number,
+  revenue: row.revenue,
+  management: parseJsonColumn(row.management),
+  productsAndServices: parseJsonColumn(row.products_and_services),
+  technologiesUsed: parseJsonColumn(row.technologies_used),
+  lastUpdated: row.last_updated,
+  ownerId: row.owner_id ?? null,
+  isPublic: row.is_public === 1,
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+});
+
+const sendJson = (res, statusCode, payload) => {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(body),
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  });
+  res.end(body);
+};
+
+const server = http.createServer(async (req, res) => {
+  if (!req.url) {
+    res.writeHead(400);
+    res.end();
+    return;
+  }
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+      'Access-Control-Max-Age': '600',
+    });
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  try {
+    if (req.method === 'GET' && url.pathname === '/api/companies') {
+      const mine = url.searchParams.get('mine') === 'true';
+
+      if (mine) {
+        const user = await authenticateRequest(req);
+        if (!user) {
+          sendJson(res, 401, { message: 'Authentication required' });
+          return;
+        }
+
+        const rows = await runQuery(`SELECT * FROM companies WHERE owner_id = ${user.id} ORDER BY updated_at DESC;`);
+        sendJson(res, 200, rows.map(mapCompanyRow));
+        return;
+      }
+
+      const rows = await runQuery('SELECT * FROM companies WHERE is_public = 1 ORDER BY company_name ASC;');
+      sendJson(res, 200, rows.map(mapCompanyRow));
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname.startsWith('/api/companies/')) {
+      const id = Number(url.pathname.replace('/api/companies/', ''));
+
+      if (!Number.isFinite(id)) {
+        sendJson(res, 400, { message: 'Invalid company id' });
+        return;
+      }
+
+      const rows = await runQuery(`SELECT * FROM companies WHERE id = ${id};`);
+
+      if (rows.length === 0) {
+        sendJson(res, 404, { message: 'Company not found' });
+        return;
+      }
+
+      const companyRow = rows[0];
+
+      if (companyRow.is_public !== 1) {
+        const user = await authenticateRequest(req);
+        if (!user || companyRow.owner_id !== user.id) {
+          sendJson(res, 403, { message: 'Access to this company is restricted' });
+          return;
+        }
+      }
+
+      sendJson(res, 200, mapCompanyRow(companyRow));
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/auth/register') {
+      const payload = await parseJsonBody(req);
+      const usernameRaw = typeof payload.username === 'string' ? payload.username.trim() : '';
+      const password = typeof payload.password === 'string' ? payload.password : '';
+
+      if (!usernameRaw) {
+        sendJson(res, 400, { message: 'Username is required' });
+        return;
+      }
+
+      if (usernameRaw.length < 3) {
+        sendJson(res, 400, { message: 'Username must be at least 3 characters long' });
+        return;
+      }
+
+      if (password.length < 8) {
+        sendJson(res, 400, { message: 'Password must be at least 8 characters long' });
+        return;
+      }
+
+      const escapedUsername = escapeSql(usernameRaw);
+      const existingUsers = await runQuery(`SELECT id FROM users WHERE username = '${escapedUsername}' LIMIT 1;`);
+
+      if (existingUsers.length > 0) {
+        sendJson(res, 409, { message: 'This username is already registered' });
+        return;
+      }
+
+      const passwordHash = hashPassword(password);
+      const escapedPassword = escapeSql(passwordHash);
+
+      const rows = await runQuery(`
+        INSERT INTO users (username, password_hash)
+        VALUES ('${escapedUsername}', '${escapedPassword}')
+        RETURNING id, username, created_at;
+      `);
+
+      if (rows.length === 0) {
+        throw new Error('Failed to create user');
+      }
+
+      const userRow = rows[0];
+      const session = await createSession(userRow.id);
+
+      sendJson(res, 201, {
+        token: session.token,
+        expiresAt: session.expiresAt,
+        user: {
+          id: userRow.id,
+          username: userRow.username,
+          createdAt: userRow.created_at,
+        },
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/auth/login') {
+      const payload = await parseJsonBody(req);
+      const usernameRaw = typeof payload.username === 'string' ? payload.username.trim() : '';
+      const password = typeof payload.password === 'string' ? payload.password : '';
+
+      if (!usernameRaw || !password) {
+        sendJson(res, 400, { message: 'Username and password are required' });
+        return;
+      }
+
+      const escapedUsername = escapeSql(usernameRaw);
+      const rows = await runQuery(`SELECT id, username, password_hash FROM users WHERE username = '${escapedUsername}' LIMIT 1;`);
+
+      if (rows.length === 0) {
+        sendJson(res, 401, { message: 'Invalid username or password' });
+        return;
+      }
+
+      const userRow = rows[0];
+
+      if (!verifyPassword(password, userRow.password_hash)) {
+        sendJson(res, 401, { message: 'Invalid username or password' });
+        return;
+      }
+
+      const session = await createSession(userRow.id);
+
+      sendJson(res, 200, {
+        token: session.token,
+        expiresAt: session.expiresAt,
+        user: {
+          id: userRow.id,
+          username: userRow.username,
+        },
+      });
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/companies') {
+      const user = await authenticateRequest(req);
+
+      if (!user) {
+        sendJson(res, 401, { message: 'Authentication required' });
+        return;
+      }
+
+      let companyRow;
+      try {
+        const payload = await parseJsonBody(req);
+        companyRow = await insertCompany(payload, user.id);
+      } catch (error) {
+        sendJson(res, 400, { message: error.message });
+        return;
+      }
+
+      if (!companyRow) {
+        throw new Error('Failed to persist company');
+      }
+
+      sendJson(res, 201, mapCompanyRow(companyRow));
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/companies/import') {
+      const user = await authenticateRequest(req);
+
+      if (!user) {
+        sendJson(res, 401, { message: 'Authentication required' });
+        return;
+      }
+
+      let payload;
+      try {
+        payload = await parseJsonBody(req);
+      } catch (error) {
+        sendJson(res, 400, { message: error.message });
+        return;
+      }
+
+      const companiesPayload = Array.isArray(payload) ? payload : Array.isArray(payload?.companies) ? payload.companies : null;
+
+      if (!companiesPayload) {
+        sendJson(res, 400, { message: 'Expected an array of companies in the request body' });
+        return;
+      }
+
+      const inserted = [];
+
+      for (let index = 0; index < companiesPayload.length; index += 1) {
+        try {
+          const companyRow = await insertCompany(companiesPayload[index], user.id);
+          if (companyRow) {
+            inserted.push(mapCompanyRow(companyRow));
+          }
+        } catch (error) {
+          sendJson(res, 400, {
+            message: `Failed to import company at index ${index}: ${error.message}`,
+          });
+          return;
+        }
+      }
+
+      sendJson(res, 201, { inserted: inserted.length, companies: inserted });
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/health') {
+      sendJson(res, 200, { status: 'ok' });
+      return;
+    }
+
+    res.writeHead(404, {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+    });
+    res.end(JSON.stringify({ message: 'Not found' }));
+  } catch (error) {
+    console.error('Request handling error:', error);
+    sendJson(res, 500, { message: 'Internal server error' });
+  }
+});
+
+ensureSchema()
+  .then(() => {
+    server.listen(PORT, () => {
+      console.log(`API server listening on http://localhost:${PORT}`);
+    });
+  })
+  .catch((error) => {
+    console.error('Failed to initialise database schema:', error);
+    process.exit(1);
+  });

--- a/server/seed.mjs
+++ b/server/seed.mjs
@@ -1,0 +1,151 @@
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const dbPath = path.join(__dirname, 'database.sqlite');
+const jsonPath = path.join(__dirname, '..', 'src', 'data', 'database.json');
+
+const escapeSql = (value) => value.replace(/'/g, "''");
+
+const runStatements = (statements) =>
+  new Promise((resolve, reject) => {
+    const child = spawn('sqlite3', [dbPath]);
+    let stderr = '';
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr || `sqlite3 exited with code ${code}`));
+      } else {
+        resolve();
+      }
+    });
+
+    statements.forEach((statement) => {
+      child.stdin.write(`${statement}\n`);
+    });
+
+    child.stdin.end();
+  });
+
+const seedDatabase = async () => {
+  const raw = await readFile(jsonPath, 'utf8');
+  const companies = JSON.parse(raw);
+
+  const statements = [
+    "PRAGMA foreign_keys = OFF;",
+    'DROP TABLE IF EXISTS companies;',
+    `CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      username TEXT NOT NULL UNIQUE,
+      password_hash TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );`,
+    `CREATE TABLE IF NOT EXISTS sessions (
+      token TEXT PRIMARY KEY,
+      user_id INTEGER NOT NULL,
+      expires_at TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    );`,
+    `CREATE TABLE companies (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      company_name TEXT NOT NULL,
+      krs_nip_or_hrb TEXT NOT NULL,
+      status TEXT NOT NULL,
+      description TEXT NOT NULL,
+      country TEXT NOT NULL,
+      industry TEXT NOT NULL,
+      employee_count TEXT NOT NULL,
+      founded_year INTEGER NOT NULL,
+      address TEXT NOT NULL,
+      website TEXT NOT NULL,
+      contact_email TEXT NOT NULL,
+      phone_number TEXT NOT NULL,
+      revenue TEXT NOT NULL,
+      management TEXT NOT NULL,
+      products_and_services TEXT NOT NULL,
+      technologies_used TEXT NOT NULL,
+      last_updated TEXT NOT NULL,
+      owner_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+      is_public INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );`,
+    'DELETE FROM sessions;',
+  ];
+
+  for (const company of companies) {
+    const values = [
+      escapeSql(company.companyName),
+      escapeSql(company.krsNIPorHRB),
+      escapeSql(company.status),
+      escapeSql(company.description),
+      escapeSql(company.country),
+      escapeSql(company.industry),
+      escapeSql(company.employeeCount),
+      company.foundedYear,
+      escapeSql(company.address),
+      escapeSql(company.website),
+      escapeSql(company.contactEmail),
+      escapeSql(company.phoneNumber),
+      escapeSql(company.revenue),
+      escapeSql(JSON.stringify(company.management ?? [])),
+      escapeSql(JSON.stringify(company.productsAndServices ?? [])),
+      escapeSql(JSON.stringify(company.technologiesUsed ?? [])),
+      escapeSql(company.lastUpdated ?? new Date().toISOString()),
+    ];
+
+    const insertStatement = `INSERT INTO companies (
+        company_name,
+        krs_nip_or_hrb,
+        status,
+        description,
+        country,
+        industry,
+        employee_count,
+        founded_year,
+        address,
+        website,
+        contact_email,
+        phone_number,
+        revenue,
+        management,
+        products_and_services,
+        technologies_used,
+        last_updated
+      ) VALUES ('${values.join("','")}');`;
+
+    statements.push(insertStatement);
+  }
+
+  statements.push('CREATE INDEX IF NOT EXISTS idx_companies_owner ON companies(owner_id);');
+  statements.push('CREATE INDEX IF NOT EXISTS idx_companies_public ON companies(is_public);');
+  statements.push('CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions(user_id);');
+  statements.push('PRAGMA foreign_keys = ON;');
+  statements.push('PRAGMA optimize;');
+
+  if (existsSync(dbPath)) {
+    await runStatements(['PRAGMA journal_mode = WAL;']);
+  }
+
+  await runStatements(statements);
+  console.log(`Seeded ${companies.length} companies into ${dbPath}`);
+};
+
+seedDatabase().catch((error) => {
+  console.error('Failed to seed database:', error);
+  process.exit(1);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,28 +1,37 @@
-import { Toaster } from "@/components/ui/toaster";
-import { Toaster as Sonner } from "@/components/ui/sonner";
-import { TooltipProvider } from "@/components/ui/tooltip";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import Index from "./pages/Index";
-import NotFound from "./pages/NotFound";
-import CompanyDetails from "./pages/CompanyDetails";
+import { Toaster } from '@/components/ui/toaster';
+import { Toaster as Sonner } from '@/components/ui/sonner';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import Index from './pages/Index';
+import NotFound from './pages/NotFound';
+import CompanyDetails from './pages/CompanyDetails';
+import Login from './pages/Login';
+import Register from './pages/Register';
+import Dashboard from './pages/Dashboard';
+import { AuthProvider } from './context/AuthContext';
 
 const queryClient = new QueryClient();
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/company/:id" element={<CompanyDetails />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
+    <AuthProvider>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/register" element={<Register />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/company/:id" element={<CompanyDetails />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </TooltipProvider>
+    </AuthProvider>
   </QueryClientProvider>
 );
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,159 @@
+/* eslint-disable react-refresh/only-export-components */
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+
+interface AuthUser {
+  id: number;
+  username: string;
+  createdAt?: string;
+}
+
+interface AuthContextValue {
+  token: string | null;
+  user: AuthUser | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (username: string, password: string) => Promise<AuthUser>;
+  register: (username: string, password: string) => Promise<AuthUser>;
+  logout: () => void;
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:4000';
+const STORAGE_KEY = 'companybi_auth_state';
+
+interface PersistedAuthState {
+  token: string;
+  user: AuthUser;
+  expiresAt?: string;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const readPersistedState = (): PersistedAuthState | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const raw = window.localStorage.getItem(STORAGE_KEY);
+
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(raw) as PersistedAuthState;
+  } catch (error) {
+    console.warn('Failed to parse persisted auth state:', error);
+    return null;
+  }
+};
+
+const persistState = (value: PersistedAuthState | null) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (value) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } else {
+    window.localStorage.removeItem(STORAGE_KEY);
+  }
+};
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const persisted = readPersistedState();
+
+    if (persisted?.token && persisted.user) {
+      setToken(persisted.token);
+      setUser(persisted.user);
+    }
+
+    setIsLoading(false);
+  }, []);
+
+  const handleAuthSuccess = useCallback((payload: PersistedAuthState) => {
+    setToken(payload.token);
+    setUser(payload.user);
+    persistState(payload);
+  }, []);
+
+  const login = useCallback(async (username: string, password: string) => {
+    const response = await fetch(`${API_BASE_URL}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+
+    if (!response.ok) {
+      let message = 'Nie udało się zalogować';
+      try {
+        const data = (await response.json()) as { message?: string };
+        if (data?.message) {
+          message = data.message;
+        }
+      } catch (error) {
+        // ignore JSON parse errors
+      }
+      throw new Error(message);
+    }
+
+    const data = (await response.json()) as PersistedAuthState;
+    handleAuthSuccess(data);
+    return data.user;
+  }, [handleAuthSuccess]);
+
+  const register = useCallback(async (username: string, password: string) => {
+    const response = await fetch(`${API_BASE_URL}/api/auth/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+
+    if (!response.ok) {
+      let message = 'Nie udało się utworzyć konta';
+      try {
+        const data = (await response.json()) as { message?: string };
+        if (data?.message) {
+          message = data.message;
+        }
+      } catch (error) {
+        // ignore JSON parse errors
+      }
+      throw new Error(message);
+    }
+
+    const data = (await response.json()) as PersistedAuthState;
+    handleAuthSuccess(data);
+    return data.user;
+  }, [handleAuthSuccess]);
+
+  const logout = useCallback(() => {
+    setToken(null);
+    setUser(null);
+    persistState(null);
+  }, []);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    token,
+    user,
+    isAuthenticated: Boolean(token && user),
+    isLoading,
+    login,
+    register,
+    logout,
+  }), [token, user, isLoading, login, register, logout]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/src/hooks/use-companies.ts
+++ b/src/hooks/use-companies.ts
@@ -1,0 +1,115 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { Company, CompanyPayload } from '@/types/company';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:4000';
+
+interface FetchCompaniesOptions {
+  mine?: boolean;
+  token?: string | null;
+}
+
+const fetchCompanies = async ({ mine = false, token }: FetchCompaniesOptions = {}): Promise<Company[]> => {
+  const url = new URL(`${API_BASE_URL}/api/companies`);
+
+  if (mine) {
+    url.searchParams.set('mine', 'true');
+  }
+
+  const response = await fetch(url.toString(), {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+
+  if (response.status === 401) {
+    throw new Error('Nie masz uprawnień do wyświetlenia tych danych.');
+  }
+
+  if (!response.ok) {
+    throw new Error('Nie udało się pobrać listy firm');
+  }
+
+  const data = (await response.json()) as Company[];
+  return data;
+};
+
+interface UseCompaniesOptions extends FetchCompaniesOptions {
+  enabled?: boolean;
+  staleTime?: number;
+}
+
+export const useCompanies = ({ mine = false, token, enabled = true, staleTime = 1000 * 60 * 5 }: UseCompaniesOptions = {}) =>
+  useQuery({
+    queryKey: ['companies', mine ? 'mine' : 'public', token ?? null],
+    queryFn: () => fetchCompanies({ mine, token }),
+    enabled: enabled && (!mine || Boolean(token)),
+    staleTime,
+  });
+
+export const fetchCompanyById = async (id: number, token?: string | null): Promise<Company | null> => {
+  const response = await fetch(`${API_BASE_URL}/api/companies/${id}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (response.status === 403) {
+    throw new Error('Nie masz dostępu do tej firmy.');
+  }
+
+  if (!response.ok) {
+    throw new Error('Nie udało się pobrać danych firmy');
+  }
+
+  return (await response.json()) as Company;
+};
+
+export const useCompany = (id?: number, token?: string | null) =>
+  useQuery({
+    queryKey: ['companies', id, token ?? null],
+    queryFn: () => fetchCompanyById(id as number, token),
+    enabled: typeof id === 'number' && Number.isFinite(id),
+  });
+
+const createCompanyRequest = async (payload: CompanyPayload, token: string): Promise<Company> => {
+  const response = await fetch(`${API_BASE_URL}/api/companies`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = 'Nie udało się zapisać firmy';
+    try {
+      const data = (await response.json()) as { message?: string };
+      if (data?.message) {
+        message = data.message;
+      }
+    } catch (error) {
+      // ignore JSON errors
+    }
+    throw new Error(message);
+  }
+
+  return (await response.json()) as Company;
+};
+
+export const useCreateCompany = (token?: string | null) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: CompanyPayload) => {
+      if (!token) {
+        throw new Error('Brak autoryzacji.');
+      }
+      return createCompanyRequest(payload, token);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['companies', 'mine'] });
+      queryClient.invalidateQueries({ queryKey: ['companies', 'public'] });
+    },
+  });
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,0 +1,314 @@
+import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useAuth } from '@/context/AuthContext';
+import { useCompanies, useCreateCompany } from '@/hooks/use-companies';
+import type { CompanyPayload } from '@/types/company';
+import { useToast } from '@/components/ui/use-toast';
+
+const parseList = (value: string) =>
+  value
+    .split(',')
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+const Dashboard = () => {
+  const navigate = useNavigate();
+  const { token, isAuthenticated, isLoading, user } = useAuth();
+  const { toast } = useToast();
+  const [error, setError] = useState<string | null>(null);
+
+  const buildInitialFormState = useMemo(
+    () =>
+      () => ({
+        companyName: '',
+        krsNIPorHRB: '',
+        status: '',
+        description: '',
+        country: '',
+        industry: '',
+        employeeCount: '',
+        foundedYear: String(new Date().getFullYear()),
+        address: '',
+        website: '',
+        contactEmail: '',
+        phoneNumber: '',
+        revenue: '',
+        management: '',
+        productsAndServices: '',
+        technologiesUsed: '',
+        lastUpdated: new Date().toISOString().slice(0, 10),
+        isPublic: true,
+      }),
+    []
+  );
+
+  const [formState, setFormState] = useState(buildInitialFormState);
+
+  const {
+    data: myCompanies = [],
+    isLoading: isLoadingCompanies,
+    isError: isCompaniesError,
+    error: companiesError,
+  } = useCompanies({ mine: true, token, enabled: isAuthenticated });
+
+  const createCompany = useCreateCompany(token);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      navigate('/login');
+    }
+  }, [isAuthenticated, isLoading, navigate]);
+
+  const handleInputChange = (field: keyof typeof formState) => (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const value = event.target.value;
+    setFormState((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!token) {
+      setError('Musisz być zalogowany, aby dodać firmę.');
+      return;
+    }
+
+    setError(null);
+
+    const payload: CompanyPayload = {
+      companyName: formState.companyName.trim(),
+      krsNIPorHRB: formState.krsNIPorHRB.trim(),
+      status: formState.status.trim(),
+      description: formState.description.trim(),
+      country: formState.country.trim(),
+      industry: formState.industry.trim(),
+      employeeCount: formState.employeeCount.trim(),
+      foundedYear: Number(formState.foundedYear),
+      address: formState.address.trim(),
+      website: formState.website.trim(),
+      contactEmail: formState.contactEmail.trim(),
+      phoneNumber: formState.phoneNumber.trim(),
+      revenue: formState.revenue.trim(),
+      management: parseList(formState.management),
+      productsAndServices: parseList(formState.productsAndServices),
+      technologiesUsed: parseList(formState.technologiesUsed),
+      lastUpdated: formState.lastUpdated ? new Date(formState.lastUpdated).toISOString() : new Date().toISOString(),
+      isPublic: formState.isPublic,
+    };
+
+    if (!Number.isInteger(payload.foundedYear)) {
+      setError('Rok założenia musi być liczbą całkowitą.');
+      return;
+    }
+
+    try {
+      await createCompany.mutateAsync(payload);
+      toast({ title: 'Dodano firmę', description: 'Wpis został zapisany w bazie danych.' });
+      setFormState(buildInitialFormState());
+    } catch (submissionError) {
+      const message = submissionError instanceof Error ? submissionError.message : 'Nie udało się zapisać firmy';
+      setError(message);
+    }
+  };
+
+  const isSubmitting = createCompany.isPending;
+
+  return (
+    <div className="min-h-screen bg-gradient-hero">
+      <div className="container mx-auto px-4 py-12">
+        <div className="mb-10 text-center text-white">
+          <h1 className="text-3xl font-semibold">Panel użytkownika</h1>
+          <p className="mt-2 text-white/70">
+            Zarządzaj własnymi wpisami i decyduj o tym, czy są widoczne publicznie.
+          </p>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_420px]">
+          <div className="space-y-6">
+            <Card className="shadow-medium">
+              <CardHeader>
+                <CardTitle>Twoje firmy</CardTitle>
+                <CardDescription>
+                  Poniżej znajdziesz listę firm utworzonych przez konto {user?.username}. Prywatne wpisy nie pojawią się na stronie
+                  głównej, dopóki nie oznaczysz ich jako publiczne.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {isLoadingCompanies && <p>Ładowanie danych...</p>}
+                {isCompaniesError && (
+                  <Alert variant="destructive">
+                    <AlertDescription>
+                      {(companiesError instanceof Error ? companiesError.message : 'Nie udało się pobrać listy firm użytkownika')}
+                    </AlertDescription>
+                  </Alert>
+                )}
+                {!isLoadingCompanies && !isCompaniesError && myCompanies.length === 0 && (
+                  <p className="text-sm text-muted-foreground">
+                    Nie dodano jeszcze żadnej firmy. Skorzystaj z formularza po prawej stronie, aby dodać pierwszą pozycję.
+                  </p>
+                )}
+                <div className="space-y-4">
+                  {myCompanies.map((company) => (
+                    <Card key={company.id} className="border border-white/10 bg-white/5">
+                      <CardHeader className="flex flex-col gap-2">
+                        <div className="flex items-center justify-between gap-4">
+                          <div>
+                            <CardTitle className="text-lg text-white">{company.companyName}</CardTitle>
+                            <CardDescription>{company.industry}</CardDescription>
+                          </div>
+                          <div className="flex flex-col items-end gap-1 text-right">
+                            <Badge variant={company.isPublic ? 'default' : 'secondary'} className={company.isPublic ? '' : 'bg-slate-200 text-slate-900'}>
+                              {company.isPublic ? 'Publiczna' : 'Prywatna'}
+                            </Badge>
+                            <span className="text-xs text-white/60">Ostatnia aktualizacja: {new Date(company.lastUpdated).toLocaleDateString()}</span>
+                          </div>
+                        </div>
+                      </CardHeader>
+                      <CardContent className="space-y-2 text-sm text-white/80">
+                        <p>{company.description}</p>
+                        <div className="flex flex-wrap gap-2">
+                          {company.technologiesUsed.slice(0, 4).map((tech) => (
+                            <Badge key={tech} variant="outline">
+                              {tech}
+                            </Badge>
+                          ))}
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+
+          <Card className="shadow-medium">
+            <CardHeader>
+              <CardTitle>Dodaj nową firmę</CardTitle>
+              <CardDescription>
+                Uzupełnij dane firmy. Listy (zarząd, produkty, technologie) możesz oddzielić przecinkami. Zmieniaj status prywatności
+                w zależności od tego, czy wpis ma być widoczny publicznie.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              {error && (
+                <Alert variant="destructive" className="mb-4">
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="companyName">Nazwa firmy</Label>
+                    <Input id="companyName" value={formState.companyName} onChange={handleInputChange('companyName')} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="krs">KRS / NIP / HRB</Label>
+                    <Input id="krs" value={formState.krsNIPorHRB} onChange={handleInputChange('krsNIPorHRB')} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="status">Status</Label>
+                    <Input id="status" value={formState.status} onChange={handleInputChange('status')} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="country">Kraj</Label>
+                    <Input id="country" value={formState.country} onChange={handleInputChange('country')} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="industry">Branża</Label>
+                    <Input id="industry" value={formState.industry} onChange={handleInputChange('industry')} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="employeeCount">Liczba pracowników</Label>
+                    <Input id="employeeCount" value={formState.employeeCount} onChange={handleInputChange('employeeCount')} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="foundedYear">Rok założenia</Label>
+                    <Input id="foundedYear" value={formState.foundedYear} onChange={handleInputChange('foundedYear')} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="lastUpdated">Data aktualizacji</Label>
+                    <Input id="lastUpdated" type="date" value={formState.lastUpdated} onChange={handleInputChange('lastUpdated')} />
+                  </div>
+                </div>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="website">Strona internetowa</Label>
+                    <Input id="website" value={formState.website} onChange={handleInputChange('website')} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="contactEmail">E-mail kontaktowy</Label>
+                    <Input id="contactEmail" type="email" value={formState.contactEmail} onChange={handleInputChange('contactEmail')} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="phoneNumber">Telefon</Label>
+                    <Input id="phoneNumber" value={formState.phoneNumber} onChange={handleInputChange('phoneNumber')} required />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="revenue">Przychody</Label>
+                    <Input id="revenue" value={formState.revenue} onChange={handleInputChange('revenue')} required />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="address">Adres</Label>
+                  <Textarea id="address" value={formState.address} onChange={handleInputChange('address')} required rows={2} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="description">Opis działalności</Label>
+                  <Textarea id="description" value={formState.description} onChange={handleInputChange('description')} required rows={4} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="management">Zarząd (lista rozdzielona przecinkami)</Label>
+                  <Textarea id="management" value={formState.management} onChange={handleInputChange('management')} rows={3} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="products">Produkty i usługi</Label>
+                  <Textarea id="products" value={formState.productsAndServices} onChange={handleInputChange('productsAndServices')} rows={3} />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="technologies">Technologie</Label>
+                  <Textarea id="technologies" value={formState.technologiesUsed} onChange={handleInputChange('technologiesUsed')} rows={3} />
+                </div>
+                <div className="flex items-center justify-between rounded-lg border border-white/10 bg-white/5 p-3">
+                  <div>
+                    <Label htmlFor="isPublic" className="text-sm font-medium text-white">
+                      Widoczność publiczna
+                    </Label>
+                    <p className="text-xs text-white/70">Po wyłączeniu wpis będzie widoczny tylko dla Ciebie po zalogowaniu.</p>
+                  </div>
+                  <Switch id="isPublic" checked={formState.isPublic} onCheckedChange={(checked) => setFormState((prev) => ({ ...prev, isPublic: checked }))} />
+                </div>
+                <Button type="submit" className="w-full" disabled={isSubmitting}>
+                  {isSubmitting ? 'Zapisywanie...' : 'Dodaj firmę'}
+                </Button>
+              </form>
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card className="mt-10 border border-dashed border-white/20 bg-white/5">
+          <CardHeader>
+            <CardTitle>Import danych przez API</CardTitle>
+            <CardDescription>
+              Możesz także przesłać wiele firm jednocześnie, wysyłając żądanie POST na <code className="rounded bg-slate-900 px-2 py-0.5">/api/companies/import</code> z tablicą obiektów w formacie JSON.
+              Wymagane pola pokrywają się z formularzem powyżej.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm text-white/70">
+            <p>
+              Użyj nagłówka <code className="rounded bg-slate-900 px-2 py-0.5">Authorization: Bearer {token ? '...token...' : 'TOKEN'}</code>, aby uwierzytelnić żądanie. Dzięki temu prywatne wpisy pozostaną widoczne tylko dla Ciebie.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import { SearchHeader } from '@/components/SearchHeader';
 import { SearchFilters } from '@/components/SearchFilters';
 import { CompanyResults, SortOption } from '@/components/CompanyResults';
@@ -7,8 +8,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Button } from '@/components/ui/button';
 import { ArrowUpRight, CheckCircle2, Compass } from 'lucide-react';
 import { useDebounce } from '@/hooks/use-debounce';
+import { useAuth } from '@/context/AuthContext';
 
 const Index = () => {
+  const navigate = useNavigate();
+  const { isAuthenticated, user, logout } = useAuth();
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedCountry, setSelectedCountry] = useState('all');
   const [selectedIndustry, setSelectedIndustry] = useState('all');
@@ -25,6 +29,11 @@ const Index = () => {
     setSelectedEmployeeRange('all');
     setSelectedStatus('all');
     setSortOption('relevance');
+  };
+
+  const handleLogout = () => {
+    logout();
+    navigate('/');
   };
 
   return (
@@ -62,13 +71,29 @@ const Index = () => {
           </nav>
 
           <div className="flex items-center gap-3">
-            <Button variant="ghost" className="text-white/80 hover:text-white">
-              Sign in
-            </Button>
-            <Button className="rounded-full bg-white px-5 py-2 text-slate-900 hover:bg-white/90">
-              Request demo
-              <ArrowUpRight className="ml-2 h-4 w-4" />
-            </Button>
+            {isAuthenticated ? (
+              <>
+                <span className="hidden text-white/70 md:inline">Witaj, {user?.username}</span>
+                <Button variant="ghost" className="text-white/80 hover:text-white" asChild>
+                  <Link to="/dashboard">Panel użytkownika</Link>
+                </Button>
+                <Button className="rounded-full bg-white px-5 py-2 text-slate-900 hover:bg-white/90" onClick={handleLogout}>
+                  Wyloguj
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button variant="ghost" className="text-white/80 hover:text-white" asChild>
+                  <Link to="/login">Zaloguj się</Link>
+                </Button>
+                <Button className="rounded-full bg-white px-5 py-2 text-slate-900 hover:bg-white/90" asChild>
+                  <Link to="/register">
+                    Utwórz konto
+                    <ArrowUpRight className="ml-2 h-4 w-4" />
+                  </Link>
+                </Button>
+              </>
+            )}
           </div>
         </header>
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,93 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useAuth } from '@/context/AuthContext';
+
+const Login = () => {
+  const navigate = useNavigate();
+  const { login, isAuthenticated, isLoading } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      navigate('/dashboard');
+    }
+  }, [isAuthenticated, isLoading, navigate]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      await login(username, password);
+      navigate('/dashboard');
+    } catch (submissionError) {
+      const message = submissionError instanceof Error ? submissionError.message : 'Nie udało się zalogować';
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-hero flex items-center justify-center px-4 py-12">
+      <Card className="w-full max-w-md shadow-medium">
+        <CardHeader className="space-y-2 text-center">
+          <CardTitle className="text-2xl font-semibold">Zaloguj się</CardTitle>
+          <CardDescription>Uzyskaj dostęp do prywatnych danych i zarządzaj własnymi firmami.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="username">Login</Label>
+              <Input
+                id="username"
+                value={username}
+                onChange={(event) => setUsername(event.target.value)}
+                placeholder="Twoja nazwa użytkownika"
+                autoComplete="username"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Hasło</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                placeholder="Wprowadź hasło"
+                autoComplete="current-password"
+                required
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? 'Logowanie...' : 'Zaloguj się'}
+            </Button>
+          </form>
+          <p className="mt-6 text-center text-sm text-muted-foreground">
+            Nie masz jeszcze konta?{' '}
+            <Link to="/register" className="text-primary hover:underline">
+              Zarejestruj się
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,0 +1,119 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useAuth } from '@/context/AuthContext';
+
+const Register = () => {
+  const navigate = useNavigate();
+  const { register: registerUser, isAuthenticated, isLoading } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && isAuthenticated) {
+      navigate('/dashboard');
+    }
+  }, [isAuthenticated, isLoading, navigate]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    if (password !== confirmPassword) {
+      setError('Hasła muszą być identyczne.');
+      return;
+    }
+
+    if (password.length < 8) {
+      setError('Hasło musi zawierać co najmniej 8 znaków.');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await registerUser(username, password);
+      navigate('/dashboard');
+    } catch (submissionError) {
+      const message = submissionError instanceof Error ? submissionError.message : 'Nie udało się utworzyć konta';
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-hero flex items-center justify-center px-4 py-12">
+      <Card className="w-full max-w-md shadow-medium">
+        <CardHeader className="space-y-2 text-center">
+          <CardTitle className="text-2xl font-semibold">Utwórz konto</CardTitle>
+          <CardDescription>Załóż konto, aby tworzyć prywatne wpisy firmowe i zarządzać ich widocznością.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {error && (
+            <Alert variant="destructive" className="mb-4">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="username">Login</Label>
+              <Input
+                id="username"
+                value={username}
+                onChange={(event) => setUsername(event.target.value)}
+                placeholder="Wybierz nazwę użytkownika"
+                autoComplete="username"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="password">Hasło</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                placeholder="Co najmniej 8 znaków"
+                autoComplete="new-password"
+                required
+                minLength={8}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="confirmPassword">Powtórz hasło</Label>
+              <Input
+                id="confirmPassword"
+                type="password"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                placeholder="Powtórz hasło"
+                autoComplete="new-password"
+                required
+                minLength={8}
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={isSubmitting}>
+              {isSubmitting ? 'Tworzenie konta...' : 'Zarejestruj się'}
+            </Button>
+          </form>
+          <p className="mt-6 text-center text-sm text-muted-foreground">
+            Masz już konto?{' '}
+            <Link to="/login" className="text-primary hover:underline">
+              Zaloguj się
+            </Link>
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default Register;

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -1,4 +1,5 @@
 export interface Company {
+  id: number;
   companyName: string;
   krsNIPorHRB: string;
   status: string;
@@ -16,4 +17,29 @@ export interface Company {
   productsAndServices: string[];
   technologiesUsed: string[];
   lastUpdated: string;
+  ownerId: number | null;
+  isPublic: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface CompanyPayload {
+  companyName: string;
+  krsNIPorHRB: string;
+  status: string;
+  description: string;
+  country: string;
+  industry: string;
+  employeeCount: string;
+  foundedYear: number;
+  address: string;
+  website: string;
+  contactEmail: string;
+  phoneNumber: string;
+  revenue: string;
+  management: string[];
+  productsAndServices: string[];
+  technologiesUsed: string[];
+  lastUpdated: string;
+  isPublic?: boolean;
 }


### PR DESCRIPTION
## Summary
- add session-based authentication, user tables, and privacy-aware company endpoints on the SQLite API
- introduce a React auth context with login/register flows and a protected dashboard for adding public or private firms
- document the authentication workflow and extend hooks/types so public pages only surface approved data

## Testing
- `npm run db:seed`
- `npm run lint` *(fails: existing lint violations in shared UI utilities and Tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_68d854463534832da23ab88ed5b9fe09